### PR TITLE
Support device filter instead of always using all NVMe devices

### DIFF
--- a/helm/nvme-ssd-provisioner/Chart.yaml
+++ b/helm/nvme-ssd-provisioner/Chart.yaml
@@ -3,5 +3,5 @@ name: nvme-ssd-provisioner
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.2.1
-appVersion: 0.2.1
+version: 0.2.2-dev1
+appVersion: 0.2.2-dev1

--- a/helm/nvme-ssd-provisioner/Chart.yaml
+++ b/helm/nvme-ssd-provisioner/Chart.yaml
@@ -3,5 +3,5 @@ name: nvme-ssd-provisioner
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.2.2-dev1
-appVersion: 0.2.2-dev1
+version: 0.2.2
+appVersion: 0.2.2

--- a/helm/nvme-ssd-provisioner/templates/daemonset.yaml
+++ b/helm/nvme-ssd-provisioner/templates/daemonset.yaml
@@ -42,10 +42,7 @@ spec:
             mountPropagation: "Bidirectional"
         {{- if .Values.env }}
         env:
-          {{- range $key, $value := .Values.env }}
-          - name: {{ $key }}
-            value: {{ $value | quote }}
-          {{- end }}
+          {{- toYaml .Values.env | nindent 10 }}
         {{- end }}
       volumes:
       - name: pv-disks

--- a/helm/nvme-ssd-provisioner/templates/daemonset.yaml
+++ b/helm/nvme-ssd-provisioner/templates/daemonset.yaml
@@ -40,6 +40,13 @@ spec:
           - mountPath: /nvme
             name: nvme
             mountPropagation: "Bidirectional"
+        {{- if .Values.env }}
+        env:
+          {{- range $key, $value := .Values.env }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+        {{- end }}
       volumes:
       - name: pv-disks
         hostPath:

--- a/helm/nvme-ssd-provisioner/values.yaml
+++ b/helm/nvme-ssd-provisioner/values.yaml
@@ -18,3 +18,5 @@ nodeSelector:
 tolerations: []
 
 affinity: {}
+
+env: {}

--- a/nvme-ssd-provisioner.sh
+++ b/nvme-ssd-provisioner.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Device filter regex - defaults to match all devices
+# Device filter regex, defaults to match all devices
 DEVICE_FILTER=${DEVICE_FILTER:-".*"}
 
 # TODO: grepping '/dev' here can potentially override the root disk if it's an NVMe device. We should make it configurable.
@@ -87,14 +87,15 @@ then
   fi
   ln -s "/pv-disks/$UUID" /nvme/disk || true
   echo "Device $DEVICE has been mounted to /pv-disks/$UUID"
+  echo "NVMe SSD provisioning is done and I will go to sleep now"
   while sleep 3600; do :; done
 fi
 
 # Perform provisioning based on nvme device count
 case $SSD_NVME_DEVICE_COUNT in
 "0")
-  echo 'No devices found of type "Amazon EC2 NVMe Instance Storage"'
-  echo "Maybe your node selectors are not set correct"
+  echo 'No devices found of type "NVMe Instance Storage"'
+  echo "Maybe your node selectors are not set correctly"
   exit 1
   ;;
 "1")


### PR DESCRIPTION
There are situations where we don't want to format every NVMe device on the host for use in the RAID array. For example, we may want to save half of the devices for use in a cluster-wide network filesystem.

This PR adds an `DEVICE_FILTER` environment variable. Any NVMe devices that have names matching this regex will be added to the RAID array.

Note that if this change is applied to nodes that have already had their NVMe devices provisioned, nothing will happen. This is intentional because we don't want to reformat all hosts at once. 