### PR TITLE
Fix/symlink race condition

### DIFF
--- a/nvme-ssd-provisioner.sh
+++ b/nvme-ssd-provisioner.sh
@@ -85,7 +85,9 @@ then
   else
     mount -o defaults,noatime,discard,nobarrier --uuid "$UUID" "/pv-disks/$UUID"
   fi
-  ln -s "/pv-disks/$UUID" /nvme/disk || true
+  # Remove any existing directory/file to prevent race condition with workload pods
+  rm -rf /nvme/disk
+  ln -s "/pv-disks/$UUID" /nvme/disk
   echo "Device $DEVICE has been mounted to /pv-disks/$UUID"
   echo "NVMe SSD provisioning is done and I will go to sleep now"
   while sleep 3600; do :; done
@@ -118,6 +120,8 @@ esac
 UUID=$(blkid -s UUID -o value "$DEVICE")
 mkdir -p "/pv-disks/$UUID"
 mount -o defaults,noatime,discard,nobarrier --uuid "$UUID" "/pv-disks/$UUID"
+# Remove any existing directory/file to prevent race condition with workload pods
+rm -rf /nvme/disk
 ln -s "/pv-disks/$UUID" /nvme/disk
 echo "Device $DEVICE has been mounted to /pv-disks/$UUID"
 echo "NVMe SSD provisioning is done and I will go to sleep now"

--- a/nvme-ssd-provisioner.sh
+++ b/nvme-ssd-provisioner.sh
@@ -86,8 +86,12 @@ then
     mount -o defaults,noatime,discard,nobarrier --uuid "$UUID" "/pv-disks/$UUID"
   fi
   # Remove any existing directory/file to prevent race condition with workload pods
+  echo "Before cleanup: $(ls -larthZ /nvme/)"
   rm -rf /nvme/disk
+  echo "After cleanup: $(ls -larthZ /nvme/)"
   ln -s "/pv-disks/$UUID" /nvme/disk
+  echo "After symlink: $(ls -larthZ /nvme/)"
+  # If symlink creation fails, check permissions and SELinux contexts shown above
   echo "Device $DEVICE has been mounted to /pv-disks/$UUID"
   echo "NVMe SSD provisioning is done and I will go to sleep now"
   while sleep 3600; do :; done
@@ -121,8 +125,12 @@ UUID=$(blkid -s UUID -o value "$DEVICE")
 mkdir -p "/pv-disks/$UUID"
 mount -o defaults,noatime,discard,nobarrier --uuid "$UUID" "/pv-disks/$UUID"
 # Remove any existing directory/file to prevent race condition with workload pods
+echo "Before cleanup: $(ls -larthZ /nvme/)"
 rm -rf /nvme/disk
+echo "After cleanup: $(ls -larthZ /nvme/)"
 ln -s "/pv-disks/$UUID" /nvme/disk
+echo "After symlink: $(ls -larthZ /nvme/)"
+# If symlink creation fails, check permissions and SELinux contexts shown above
 echo "Device $DEVICE has been mounted to /pv-disks/$UUID"
 echo "NVMe SSD provisioning is done and I will go to sleep now"
 


### PR DESCRIPTION
to ensure workload pods always find it before on `first attempt`..can have init container checking  /nvme/disk/ raid0 symlink path is available first instead of directly using  /nvme/disk/tmp-fireworks in hostpath (on retry it might still find it ..but still run into race if it creates the path early..workload pod if retries (most pods have this behvaiour) will find the nvme ssd provisioner path and shud continue)